### PR TITLE
Minor tweaks

### DIFF
--- a/core/components/tinymcerte/model/tinymcerte/events/tinymcerteonrichtexteditorinit.class.php
+++ b/core/components/tinymcerte/model/tinymcerte/events/tinymcerteonrichtexteditorinit.class.php
@@ -23,6 +23,7 @@ class TinyMCERTEOnRichTextEditorInit extends TinyMCERTEPlugin {
         $this->modx->regClientStartupScript($this->tinymcerte->getOption('jsUrl') . 'mgr/tinymcerte.js');
 
         return '<script type="text/javascript">
+            Ext.ns("TinyMCERTE");
             TinyMCERTE.editorConfig = ' . $this->modx->toJSON($this->getTinyConfig()) . ';
 
             Ext.onReady(function(){

--- a/core/components/tinymcerte/model/tinymcerte/tinymcerte.class.php
+++ b/core/components/tinymcerte/model/tinymcerte/tinymcerte.class.php
@@ -34,7 +34,6 @@ class TinyMCERTE {
             'connectorUrl' => $assetsUrl . 'connector.php'
         ), $options);
 
-        $this->modx->addPackage('tinymcerte', $this->getOption('modelPath'));
         $this->modx->lexicon->load('tinymcerte:default');
     }
 


### PR DESCRIPTION
### What does it do ?

1. remove un-needed `modX::addPackage` call
2. make sure ExtJS `TinyMCERTE` namespace is defined

### Why is it needed ?

1. causes some warning about missing model meta data information (TinyMCE does not provide xPDO models)
2. when loading the RTE in some CMP, `TinyMCERTE` could be undefined, making the `editorConfig` attribute not being set, with custom configuration
