### PR TITLE
Support for the working context in the media browser

### DIFF
--- a/assets/components/tinymcerte/js/mgr/tinymcerte.js
+++ b/assets/components/tinymcerte/js/mgr/tinymcerte.js
@@ -63,7 +63,7 @@ Ext.extend(TinyMCERTE.Tiny,Ext.Component,{
     ,loadBrowser: function(field_name, url, type, win) {
         tinyMCE.activeEditor.windowManager.open({
             title: "MODX Resource Browser",
-            url: MODx.config['manager_url'] + 'index.php?a=' + MODx.action['browser'] + '&source=' + MODx.config['default_media_source'],
+            url: MODx.config['manager_url'] + 'index.php?a=' + MODx.action['browser'] + '&source=' + MODx.config['default_media_source'] + (MODx.ctx ? ('&ctx=' + MODx.ctx) : ''),
             width: 1000,
             height: 500
         }, {


### PR DESCRIPTION
### What does it do ?

Take take of the currently edited resource context to load the media browser.
### Why is it needed ?

It makes use of the context configured default media source
### Related issue(s)/PR(s)
- Fixes #31 
