### PR TITLE
Change regClientStartupScript to controller->addJavascript

### DIFF
--- a/core/components/tinymcerte/model/tinymcerte/events/tinymcerteonrichtexteditorinit.class.php
+++ b/core/components/tinymcerte/model/tinymcerte/events/tinymcerteonrichtexteditorinit.class.php
@@ -18,9 +18,9 @@ class TinyMCERTEOnRichTextEditorInit extends TinyMCERTEPlugin {
     }
 
     private function initTinyMCE() {
-        $this->modx->regClientStartupScript($this->tinymcerte->getOption('jsUrl') . 'vendor/tinymce/tinymce.min.js');
-        $this->modx->regClientStartupScript($this->tinymcerte->getOption('jsUrl') . 'vendor/autocomplete.js');
-        $this->modx->regClientStartupScript($this->tinymcerte->getOption('jsUrl') . 'mgr/tinymcerte.js');
+        $this->modx->controller->addJavascript($this->tinymcerte->getOption('jsUrl') . 'vendor/tinymce/tinymce.min.js');
+        $this->modx->controller->addJavascript($this->tinymcerte->getOption('jsUrl') . 'vendor/autocomplete.js');
+        $this->modx->controller->addJavascript($this->tinymcerte->getOption('jsUrl') . 'mgr/tinymcerte.js');
 
         return '<script type="text/javascript">
             Ext.ns("TinyMCERTE");


### PR DESCRIPTION
For some better CMP support i.e. for ClientConfig and the next version of Glossary which uses controller->addHtml.

Without adding this, a javascript error: 'Uncaught ReferenceError: TinyMCERTE is not defined' is shown, and TinyMCE RTE is displayed with some default template not using the MODX system settings.

Fixes #48