### PR TITLE
Adding new variables to allow https urls in media sources Issue #51 

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -93,6 +93,14 @@
         },{
             "key": "skin",
             "value": "modx"
+        },{
+            "key": "relative_urls",
+            "value": true,
+            "type": "combo-boolean"
+        },{
+            "key": "remove_script_host",
+            "value": true,
+            "type": "combo-boolean"
         }]
     }
     ,"build": {

--- a/core/components/tinymcerte/model/tinymcerte/events/tinymcerteonrichtexteditorinit.class.php
+++ b/core/components/tinymcerte/model/tinymcerte/events/tinymcerteonrichtexteditorinit.class.php
@@ -65,6 +65,8 @@ class TinyMCERTEOnRichTextEditorInit extends TinyMCERTEPlugin {
             'content_css' => $this->tinymcerte->explodeAndClean($this->tinymcerte->getOption('content_css', array(), '')),
             'image_class_list' => $this->modx->fromJSON($this->tinymcerte->getOption('image_class_list', array(), '[]')),
             'skin' => $this->tinymcerte->getOption('skin', array(), 'modx'),
+            'relative_urls' => $this->tinymcerte->getOption('relative_urls', array(), true) == 1,
+            'remove_script_host'=> $this->tinymcerte->getOption('remove_script_host', array(), true) == 1,
         );
 
         $styleFormats = $this->tinymcerte->getOption('style_formats', array(), '[]');


### PR DESCRIPTION
I've added the `relative_urls` and `remove_script_host` to resolve the issue with https based media sources found in issue #51 