### PR TITLE
Adding valid_elements option

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -101,6 +101,9 @@
             "key": "remove_script_host",
             "value": true,
             "type": "combo-boolean"
+        },{
+            "key": "valid_elements",
+            "value": ""
         }]
     }
     ,"build": {

--- a/core/components/tinymcerte/model/tinymcerte/events/tinymcerteonrichtexteditorinit.class.php
+++ b/core/components/tinymcerte/model/tinymcerte/events/tinymcerteonrichtexteditorinit.class.php
@@ -91,6 +91,11 @@ class TinyMCERTEOnRichTextEditorInit extends TinyMCERTEPlugin {
             $config['style_formats'] = $finalFormats;
         }
 
+        $validElements = $this->tinymcerte->getOption('valid_elements');
+        if(!empty($validElements)){
+            $config['valid_elements'] = $validElements;
+        }
+
         $externalConfig = $this->tinymcerte->getOption('external_config');
         if (!empty($externalConfig)) {
             $externalConfig = str_replace('{base_path}', $this->modx->getOption('base_path'), $externalConfig);

--- a/core/components/tinymcerte/model/tinymcerte/events/tinymcerteonrichtexteditorinit.class.php
+++ b/core/components/tinymcerte/model/tinymcerte/events/tinymcerteonrichtexteditorinit.class.php
@@ -18,9 +18,9 @@ class TinyMCERTEOnRichTextEditorInit extends TinyMCERTEPlugin {
     }
 
     private function initTinyMCE() {
-        $this->modx->regClientStartupScript($this->tinymcerte->getOption('jsUrl') . 'vendor/tinymce/tinymce.min.js');
-        $this->modx->regClientStartupScript($this->tinymcerte->getOption('jsUrl') . 'vendor/autocomplete.js');
-        $this->modx->regClientStartupScript($this->tinymcerte->getOption('jsUrl') . 'mgr/tinymcerte.js');
+        $this->modx->controller->addJavascript($this->tinymcerte->getOption('jsUrl') . 'vendor/tinymce/tinymce.min.js');
+        $this->modx->controller->addJavascript($this->tinymcerte->getOption('jsUrl') . 'vendor/autocomplete.js');
+        $this->modx->controller->addJavascript($this->tinymcerte->getOption('jsUrl') . 'mgr/tinymcerte.js');
 
         return '<script type="text/javascript">
             Ext.ns("TinyMCERTE");


### PR DESCRIPTION
We have many cases where we like to limit the options of valid elements available in tinyMCE.  The is especially true when the client is copy/pasting from an existing site that injects a lot of extra formats. https://www.tinymce.com/docs/configure/content-filtering/#valid_elements