### PR TITLE
[Feature]Add support to filter resources from other contexts when creating internal links

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -103,7 +103,7 @@
             "type": "combo-boolean"
         },{
             "key": "links_across_contexts",
-            "value": false,
+            "value": true,
             "type": "combo-boolean"
         }]
     }

--- a/_build/config.json
+++ b/_build/config.json
@@ -101,6 +101,10 @@
             "key": "remove_script_host",
             "value": true,
             "type": "combo-boolean"
+        },{
+            "key": "links_across_contexts",
+            "value": false,
+            "type": "combo-boolean"
         }]
     }
     ,"build": {

--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
@@ -402,7 +402,7 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 			// the hintsFetcher is your customized function which searchs the proper autocomplete hints based on the user's input value.
 			hintsFetcher : function (v, openList) {
 				_resultDataset = {};
-				var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?q='+v);
+				var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?q='+v+'&ctx='+MODx.ctx);
 				xhr.open('GET', _link);
 				xhr.onload = function() {
 					if (xhr.status === 200) {

--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/search.php
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/search.php
@@ -11,11 +11,28 @@ require_once MODX_CONNECTORS_PATH.'index.php';
 $query = $modx->getOption('q',$_REQUEST,'');
 if(strlen($query) < 3) exit();
 
+// System setting defines if we should list links across contexts or not
+$across_contexts = $modx->getOption('tinymcerte.links_across_contexts', null, true);
+
 $c = $modx->newQuery('modResource');
-$c->where(array(
-    'pagetitle:LIKE' => '%'.$query.'%',
-    'OR:alias:LIKE' => '%'.$query.'%',
+
+// Note, reason we nest the query in two array is because if we are going to filter on context, we want the final query on the form:
+// ((pagetitle or alias) and context). If we don't filter on context, it will make no difference that the where clause has an extra
+// parenthesis
+$where_clause = array(array(
+  'pagetitle:LIKE' => '%'.$query.'%',
+  'OR:alias:LIKE' => '%'.$query.'%',
 ));
+
+if (!$across_contexts) {
+  if (isset($_GET['ctx']) and strlen($_GET['ctx'])) {
+	$where_clause[] = array(
+      'context_key' => $_GET['ctx']
+	);
+  }
+}
+
+$c->where($where_clause);
 
 $count = $modx->getCount('modResource',$c);
 
@@ -23,6 +40,7 @@ $c->select(array('id','pagetitle','alias'));
 $c->limit(10);
 
 $resources = $modx->getCollection('modResource',$c);
+
 $a = array();
 foreach ($resources as $resource) {
 	$a[] = array(

--- a/core/components/tinymcerte/lexicon/en/default.inc.php
+++ b/core/components/tinymcerte/lexicon/en/default.inc.php
@@ -53,4 +53,6 @@ $_lang['setting_tinymcerte.external_config'] = 'External config';
 $_lang['setting_tinymcerte.external_config_desc'] = 'Path to the external config file, that will be merged with with defaults from system setting. Config file has to contain valid JSON object.';
 $_lang['setting_tinymcerte.skin'] = 'Skin';
 $_lang['setting_tinymcerte.skin_desc'] = 'Select what skin to use, this should match the foldername of the skin. <a href="http://www.tinymce.com/wiki.php/Configuration:skin">http://www.tinymce.com/wiki.php/Configuration:skin</a>';
+$_lang['setting_tinymcerte.links_across_contexts'] = 'Links across contexts';
+$_lang['setting_tinymcerte.links_across_contexts_desc'] = 'If turned on, the editor will list Resources from other contexts when creating internal links. If turned off, only Resources from the same context appear.';
 


### PR DESCRIPTION
Some of our MODX sites have contexts that are separated, with users limited to only one of them. We're using this extra, and when creating internal MODX links, the suggestions will list Resources outside the current context.

This PR adds functionality via a system setting to only list Resources from the same context. This setting is called `links_across_contexts` and is turned on by default to avoid breaking changes.

I hope you'll accept this PR. We use this extra a lot and would love to see this feature implemented in the official version, rather than relying on our own fork.

With the default value (across contexts), created from the web context:
<img width="792" alt="skarmavbild 2016-11-23 kl 21 18 54" src="https://cloud.githubusercontent.com/assets/2326278/20578282/e53ea3f0-b1c6-11e6-9646-74a623551164.png">

With the value set to false (not across contexts), created from the web context:
<img width="818" alt="skarmavbild 2016-11-23 kl 21 18 13" src="https://cloud.githubusercontent.com/assets/2326278/20578294/f66fd9e6-b1c6-11e6-9fab-8af49dd5baaa.png">
