### PR TITLE
bugfix modxlink search clientconfig

### DIFF
--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
@@ -402,7 +402,7 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 			// the hintsFetcher is your customized function which searchs the proper autocomplete hints based on the user's input value.
 			hintsFetcher : function (v, openList) {
 				_resultDataset = {};
-				var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?q='+v+'&ctx='+MODx.ctx);
+				var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?q='+v+'&context='+MODx.ctx);
 				xhr.open('GET', _link);
 				xhr.onload = function() {
 					if (xhr.status === 200) {

--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/search.php
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/search.php
@@ -4,6 +4,7 @@
  *
  * @package tinymce
  */
+
 require_once dirname(dirname(dirname(dirname(dirname(dirname(dirname(dirname(dirname(__FILE__))))))))).'/config.core.php';
 require_once MODX_CORE_PATH.'config/'.MODX_CONFIG_KEY.'.inc.php';
 require_once MODX_CONNECTORS_PATH.'index.php';
@@ -25,16 +26,14 @@ $where_clause = array(array(
 ));
 
 if (!$across_contexts) {
-  if (isset($_GET['ctx']) and strlen($_GET['ctx'])) {
+  if (isset($_GET['context']) and strlen($_GET['context']) and $_GET['context'] == 'undefined') {
 	$where_clause[] = array(
-      'context_key' => $_GET['ctx']
+      'context_key' => $_GET['context']
 	);
   }
 }
 
 $c->where($where_clause);
-
-$count = $modx->getCount('modResource',$c);
 
 $c->select(array('id','pagetitle','alias'));
 $c->limit(10);


### PR DESCRIPTION
if you search for a resource when used tinymce on clientconfig, it produce an error because of an undefined contextkey.