### PR TITLE
Added field displaying resource pagetitle of MODX link

### DIFF
--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
@@ -136,7 +136,7 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 			}
 
 			var resourceId = link.replace('[[~', '').replace(']]', '');
-			var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?id=' + resourceId + '&ctx='+MODx.ctx);
+			var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?id=' + resourceId + '&context='+MODx.ctx);
 			xhr.open('GET', _link);
 			xhr.onload = function() {
 				if (xhr.status === 200) {
@@ -455,7 +455,7 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 			// the hintsFetcher is your customized function which searchs the proper autocomplete hints based on the user's input value.
 			hintsFetcher : function (v, openList) {
 				_resultDataset = {};
-				var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?q='+v+'&ctx='+MODx.ctx);
+				var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?q='+v+'&context='+MODx.ctx);
 				xhr.open('GET', _link);
 				xhr.onload = function() {
 					if (xhr.status === 200) {

--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
@@ -120,6 +120,49 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 			if (!meta.text) {
 				updateText.call(this);
 			}
+
+			getPagetitleForModxLink(this.value());
+		}
+		
+		function isModxLink(link)
+		{
+			return (link.startsWith('[[~') && link.endsWith(']]'));
+		}
+
+		function getPagetitleForModxLink(link)
+		{
+			if (!isModxLink(link)) {
+				setRenderedPagetitle('');
+			}
+
+			var resourceId = link.replace('[[~', '').replace(']]', '');
+			var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?id=' + resourceId + '&ctx='+MODx.ctx);
+			xhr.open('GET', _link);
+			xhr.onload = function() {
+				if (xhr.status === 200) {
+					var _results = Ext.util.JSON.decode(xhr.responseText),
+						_e = [];
+
+					if (_results.pagetitle) {
+						setRenderedPagetitle(_results.pagetitle);
+					}
+				} else {
+					console.error('ajax error', _link);
+				}
+			};
+
+			xhr.send();
+		}
+
+		function setRenderedPagetitle(pagetitle)
+		{
+			// Fix so the pagetitlerender field is always rendered properly.
+			if (pagetitle === '') {
+				pagetitle = '&nbsp;';
+			}
+
+			_rendertitle = document.querySelector("#link-pagetitlerender i");
+			_rendertitle.innerHTML = pagetitle;
 		}
 
 		function isOnlyTextSelected(anchorElm) {
@@ -272,6 +315,16 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 					onkeyup: updateText
 				},
 				{
+					type: 'container',
+					name: 'pagetitle',
+					id: 'link-pagetitlerender',
+					label: ' ',
+					html: '<i>&nbsp;</i>',
+					onPostRender: function () {
+						getPagetitleForModxLink(data.href);
+					}
+				},
+				{
 					name: 'search',
 					type: 'textbox',
 					label: 'Search',
@@ -402,7 +455,7 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 			// the hintsFetcher is your customized function which searchs the proper autocomplete hints based on the user's input value.
 			hintsFetcher : function (v, openList) {
 				_resultDataset = {};
-				var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?q='+v+'&context='+MODx.ctx);
+				var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?q='+v+'&ctx='+MODx.ctx);
 				xhr.open('GET', _link);
 				xhr.onload = function() {
 					if (xhr.status === 200) {
@@ -420,9 +473,14 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 			}
 		});
 		input.autoComplt.setListener('select', function(e,r) {
-			var _a = document.querySelector("#link-href input"), _title = document.querySelector("#text-to-display");
+			var _a = document.querySelector("#link-href input"),
+				_title = document.querySelector("#text-to-display"),
+				_rendertitle = document.querySelector("#link-pagetitlerender i");
+
 			_a.value = "[[~"+_resultDataset[this.value].id+"]]";
 			if(_title.value == "") _title.value = _resultDataset[this.value].title
+
+			_rendertitle.innerHTML = _resultDataset[this.value].pagetitle;
 		});
 
 	}
@@ -457,4 +515,3 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 		prependToContext: true
 	});
 });
-

--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
@@ -126,7 +126,7 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 
 		function isModxLink(link)
 		{
-			return (link.startsWith('[[~') && link.endsWith(']]'));
+			return link.match(/\[\[~(.*)\]\]$/g);
 		}
 
 		function getPagetitleForModxLink(link)
@@ -134,7 +134,7 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 			if (!isModxLink(link)) {
 				setRenderedPagetitle('');
 			} else {
-				var resourceId = link.replace('[[~', '').replace(']]', '');
+				var resourceId = link.replace(/\[\[~(\d*).*\]\]$/g, '$1');
 				var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?id=' + resourceId + '&context='+MODx.ctx);
 				xhr.open('GET', _link);
 				xhr.onload = function() {

--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
@@ -123,7 +123,7 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 
 			getPagetitleForModxLink(this.value());
 		}
-		
+
 		function isModxLink(link)
 		{
 			return (link.startsWith('[[~') && link.endsWith(']]'));
@@ -474,15 +474,13 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 		});
 		input.autoComplt.setListener('select', function(e,r) {
 			var _a = document.querySelector("#link-href input"),
-				_title = document.querySelector("#text-to-display"),
-				_rendertitle = document.querySelector("#link-pagetitlerender i");
+				_title = document.querySelector("#text-to-display");
 
 			_a.value = "[[~"+_resultDataset[this.value].id+"]]";
 			if(_title.value == "") _title.value = _resultDataset[this.value].title
 
-			_rendertitle.innerHTML = _resultDataset[this.value].pagetitle;
+			setRenderedPagetitle(_resultDataset[this.value].pagetitle)
 		});
-
 	}
 
 	editor.addButton('link', {

--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/plugin.min.js
@@ -133,25 +133,25 @@ tinymce.PluginManager.add('modxlink', function(editor) {
 		{
 			if (!isModxLink(link)) {
 				setRenderedPagetitle('');
-			}
+			} else {
+				var resourceId = link.replace('[[~', '').replace(']]', '');
+				var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?id=' + resourceId + '&context='+MODx.ctx);
+				xhr.open('GET', _link);
+				xhr.onload = function() {
+					if (xhr.status === 200) {
+						var _results = Ext.util.JSON.decode(xhr.responseText),
+							_e = [];
 
-			var resourceId = link.replace('[[~', '').replace(']]', '');
-			var xhr = new XMLHttpRequest(), _link = encodeURI(TinyMCERTE.editorConfig.modxlinkSearch+'?id=' + resourceId + '&context='+MODx.ctx);
-			xhr.open('GET', _link);
-			xhr.onload = function() {
-				if (xhr.status === 200) {
-					var _results = Ext.util.JSON.decode(xhr.responseText),
-						_e = [];
-
-					if (_results.pagetitle) {
-						setRenderedPagetitle(_results.pagetitle);
+						if (_results.pagetitle) {
+							setRenderedPagetitle(_results.pagetitle);
+						}
+					} else {
+						console.error('ajax error', _link);
 					}
-				} else {
-					console.error('ajax error', _link);
-				}
-			};
+				};
 
-			xhr.send();
+				xhr.send();
+			}
 		}
 
 		function setRenderedPagetitle(pagetitle)

--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/search.php
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/search.php
@@ -4,10 +4,22 @@
  *
  * @package tinymce
  */
-
 require_once dirname(dirname(dirname(dirname(dirname(dirname(dirname(dirname(dirname(__FILE__))))))))).'/config.core.php';
 require_once MODX_CORE_PATH.'config/'.MODX_CONFIG_KEY.'.inc.php';
 require_once MODX_CONNECTORS_PATH.'index.php';
+
+$id = $modx->getOption('id', $_REQUEST, '');
+if (!empty($id)) {
+    $resource = $modx->getObject('modResource', $id);
+    if ($resource) {
+        exit(json_encode([
+            'id'        => $resource->get('id'),
+            'pagetitle' => htmlspecialchars($resource->get('pagetitle')) . " (" . $resource->get('id') . ")",
+            'title'     => $resource->get('pagetitle'),
+            'alias'     => $resource->get('alias')
+        ]));
+    }
+}
 
 $query = $modx->getOption('q',$_REQUEST,'');
 if(strlen($query) < 3) exit();
@@ -26,14 +38,16 @@ $where_clause = array(array(
 ));
 
 if (!$across_contexts) {
-  if (isset($_GET['context']) and strlen($_GET['context']) and $_GET['context'] == 'undefined') {
+  if (isset($_GET['ctx']) and strlen($_GET['ctx'])) {
 	$where_clause[] = array(
-      'context_key' => $_GET['context']
+      'context_key' => $_GET['ctx']
 	);
   }
 }
 
 $c->where($where_clause);
+
+$count = $modx->getCount('modResource',$c);
 
 $c->select(array('id','pagetitle','alias'));
 $c->limit(10);

--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/search.php
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/search.php
@@ -38,11 +38,11 @@ $where_clause = array(array(
 ));
 
 if (!$across_contexts) {
-  if (isset($_GET['ctx']) and strlen($_GET['ctx'])) {
-	$where_clause[] = array(
-      'context_key' => $_GET['ctx']
-	);
-  }
+    if (isset($_GET['context']) and strlen($_GET['context']) and $_GET['context'] == 'undefined') {
+        $where_clause[] = array(
+            'context_key' => $_GET['context']
+        );
+    }
 }
 
 $c->where($where_clause);

--- a/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/search.php
+++ b/assets/components/tinymcerte/js/vendor/tinymce/plugins/modxlink/search.php
@@ -8,8 +8,8 @@ require_once dirname(dirname(dirname(dirname(dirname(dirname(dirname(dirname(dir
 require_once MODX_CORE_PATH.'config/'.MODX_CONFIG_KEY.'.inc.php';
 require_once MODX_CONNECTORS_PATH.'index.php';
 
-$id = $modx->getOption('id', $_REQUEST, '');
-if (!empty($id)) {
+$id = (int) $modx->getOption('id', $_REQUEST, 0);
+if ($id > 0) {
     $resource = $modx->getObject('modResource', $id);
     if ($resource) {
         exit(json_encode([


### PR DESCRIPTION
### What does it do?
I've added a field which will display the MODX resource pagetitle if the URL field contains a valid MODX link.

### Why is it needed?
For many (non-technical) users it is not clear to what resource the URL links to. Now it is more clear to which resource is being linked.

**External link:**
![Screenshot 2019-04-23 at 13 21 21](https://user-images.githubusercontent.com/7802465/56577206-b4a4a900-65ca-11e9-9131-a1a242e18e1f.png)

**Internal link:**
![Screenshot 2019-04-23 at 13 21 04](https://user-images.githubusercontent.com/7802465/56577220-b9695d00-65ca-11e9-8727-702ff8bdb278.png)
