### PR TITLE
Fixed modx theme styles

### DIFF
--- a/assets/components/tinymcerte/js/vendor/tinymce/skins/modx/skin.min.css
+++ b/assets/components/tinymcerte/js/vendor/tinymce/skins/modx/skin.min.css
@@ -4,6 +4,10 @@
 	color: #555555;
 }
 
+.mce-widget.mce-tooltip * {
+	color: #ffffff;
+}
+
 .mce-tinymce {
 	-moz-box-shadow: none;
 	-webkit-box-shadow: none;
@@ -35,7 +39,7 @@
 }
 
 .mce-grid-border a:hover, .mce-grid-border a.mce-active {
-	background: #2b9385;
+	background: #2d86b7;
 	border-color: #cccccc;
 }
 
@@ -76,6 +80,7 @@
 .mce-panel {
 	background-color: #fbfbfb;
 	border: 0 solid #dddddd;
+	border-radius: 3px;
 }
 
 .mce-floatpanel {
@@ -121,28 +126,37 @@
 }
 
 .mce-window-head {
-	border-bottom: 1px solid #dddddd;
+	background-color: #F0F0F0;
+	border-bottom: 1px solid #DCDCDC;
+	border-radius: 3px 3px 0 0;
+	color: #555555;
 }
 
 .mce-window-head .mce-close {
 	color: #999999;
 	font-size: 20px;
-	font-weight: bold;
 	height: 20px;
 	line-height: 20px;
 	overflow: hidden;
-	right: 3px;
 	top: 12px;
+}
 
 .mce-window-head .mce-close i {
+	border-radius: 50%;
 	color: #999999;
+	font-size: 12px;
+	text-align: center;
+	padding: 1px;
 }
 
 .mce-close:hover i {
-	color: #e5e5e5;
+	background: #3697cd;
+	color: #FFF;
 }
 
 .mce-window-head .mce-title {
+	font-size: 18px;
+	font-weight: 400;
 	padding-right: 10px;
 }
 
@@ -185,7 +199,8 @@
 .mce-btn {
 	background: #fafafa;
 	border: 1px solid #e9e9e9;
-	border-color: #e5e5e5 #e5e5e5 #e5e5e5 #e5e5e5;
+	border-color: #e5e5e5;
+	border-radius: 3px;
 }
 
 .mce-btn:hover, .mce-btn:active {
@@ -205,15 +220,15 @@
 }
 
 .mce-btn.mce-active button, .mce-btn.mce-active:hover button, .mce-btn.mce-active i, .mce-btn.mce-active:hover i {
-	color: #e0e0e0;
+	color: #555555;
 }
 
 .mce-btn:hover .mce-caret {
-	border-top-color: #ededed;
+	border-top-color: #555555;
 }
 
 .mce-btn.mce-active .mce-caret, .mce-btn.mce-active:hover .mce-caret {
-	border-top-color: #e0e0e0;
+	border-top-color: #555555;
 }
 
 .mce-btn button {
@@ -225,19 +240,20 @@
 }
 
 .mce-primary {
-	background-color: #2fa192;
-	border: 1px solid #e9e9e9;
-	border-color: #e5e5e5 #e5e5e5 #e5e5e5 #e5e5e5;
+	background-color: #32AB9A;
+	background-image: linear-gradient(#32AB9A, #00948E);
+	border: 1px solid transparent;
 	color: #ffffff;
-	min-width: 50px;
 }
 
 .mce-primary:hover, .mce-primary:focus {
-	background-color: #298e80;
+	background-color: #2b9385;
+	background-image: linear-gradient(#2b9385, #007571);
 }
 
 .mce-primary.mce-active, .mce-primary.mce-active:hover, .mce-primary:not(.mce-disabled):active {
-	background-color: #247a6e;
+	background-color: #2b9385;
+	background-image: linear-gradient(#2b9385, #007571);
 }
 
 .mce-primary button, .mce-primary button i {
@@ -267,6 +283,7 @@ i.mce-i-checkbox {
 }
 
 .mce-checked i.mce-i-checkbox {
+	border-radius: 3px;
 	color: #555555;
 }
 
@@ -281,6 +298,7 @@ i.mce-i-checkbox {
 .mce-combobox input {
 	border: 1px solid #dddddd;
 	border-right-color: #dddddd;
+	border-radius: 3px;
 }
 
 .mce-combobox.mce-disabled input {
@@ -310,6 +328,7 @@ i.mce-i-checkbox {
 
 .mce-path-item {
 	color: #555555;
+}
 
 .mce-path-item:focus {
 	background: #666666;
@@ -322,6 +341,19 @@ i.mce-i-checkbox {
 
 .mce-label.mce-error {
 	color: #aa0000;
+}
+
+.mce-menu {
+	-moz-box-shadow: none;
+	-webkit-box-shadow: none;
+	box-shadow: none;
+	margin: 2px 0 0;
+	max-height: 400px;
+	min-width: 160px;
+}
+
+.mce-menu .mce-menu-item-sep, .mce-menu-item-sep:hover {
+	margin: 1px !important;
 }
 
 .mce-menubar {
@@ -354,6 +386,10 @@ i.mce-i-checkbox {
 	padding: 6px 15px 6px 12px;
 }
 
+.mce-menu-item.mce-active.mce-menu-item-normal {
+	background: #2d86b7;
+}
+
 .mce-menu-item .mce-caret {
 	border-left: 4px solid #555555;
 }
@@ -362,8 +398,8 @@ i.mce-i-checkbox {
 	color: #555555;
 }
 
-.mce-menu-item:hover, .mce-menu-item:focus {
-	background-color: #2b9385;
+.mce-menu-item:hover, .mce-menu-item:focus, .mce-menu-item.mce-selected {
+	background-color: #30759c;
 	color: #ffffff;
 }
 
@@ -371,16 +407,12 @@ i.mce-i-checkbox {
 	color: #ffffff;
 }
 
-.mce-menu-item.mce-selected {
-	background: #2b9385;
-}
-
 .mce-menu-item.mce-selected .mce-text, .mce-menu-item.mce-selected .mce-ico {
 	color: #ffffff;
 }
 
 .mce-menu-item.mce-disabled:focus, .mce-menu-item.mce-disabled:hover:focus {
-	background: #2b9385;
+	background: #30759c;
 }
 
 .mce-menu-item.mce-menu-item-preview.mce-active .mce-text, .mce-menu-item.mce-menu-item-preview.mce-active .mce-ico {
@@ -388,16 +420,11 @@ i.mce-i-checkbox {
 }
 
 .mce-menu-item.mce-menu-item-preview.mce-active:hover {
-	background: #2b9385;
+	background: #30759c;
 }
 
 .mce-menu-item:hover *, .mce-menu-item.mce-selected *, .mce-menu-item:focus * {
 	color: #ffffff;
-}
-
-div.mce-menu .mce-menu-item-sep, .mce-menu-item-sep:hover {
-	background: #dddddd;
-	border-bottom: 1px solid #ffffff;
 }
 
 .mce-rtl .mce-menu-item .mce-caret {
@@ -406,17 +433,6 @@ div.mce-menu .mce-menu-item-sep, .mce-menu-item-sep:hover {
 
 .mce-rtl .mce-menu-item.mce-selected .mce-caret, .mce-rtl .mce-menu-item:focus .mce-caret, .mce-rtl .mce-menu-item:hover .mce-caret {
 	border-right-color: #ffffff;
-}
-
-.mce-menu {
-	background: #ffffff;
-	border: 1px solid #e5e5e5;
-	-moz-box-shadow: none;
-	-webkit-box-shadow: none;
-	box-shadow: none;
-	margin: 2px 0 0;
-	max-height: 400px;
-	min-width: 160px;
 }
 
 i.mce-i-resize {
@@ -440,35 +456,38 @@ i.mce-i-resize {
 }
 
 .mce-tabs {
+	background: none;
 	border-bottom: 1px solid #e5e5e5;
+	margin-top: 5px;
 }
 
 .mce-tab {
-	background: #eeeeee;
-	border: 1px solid #e5e5e5;
+	color: #1A7FB8;
+	background: none;
+	border: 1px solid transparent;
 	padding: 8px;
 }
 
-.mce-tab:hover {
-	background: #ffffff;
-}
-
 .mce-tab.mce-active {
-	background: #fcfcfc;
+	border-top: 2px solid #1A7FB8;
+	border-left: 1px solid #e5e5e5;
+	border-right: 1px solid #e5e5e5;
+
 }
 
-.mce-tab:focus {
-	color: #fcfcfc;
+.mce-tab:hover, .mce-tab:focus {
+	color: #1f5c7e;
 }
 
 .mce-textbox {
 	background: #f2f2f2;
 	border: 1px solid #dddddd;
+	border-radius: 3px;
 	color: #555555;
 }
 
 .mce-textbox:focus, .mce-textbox.mce-focus {
-	border-color: #555555;
+	border-color: #2d86b7;
 }
 
 .mce-textbox.mce-disabled {


### PR DESCRIPTION
### What does it do?
Due to styling errors (no closing parenthesis), modx theme styles were practically not working - https://github.com/modxcms/tinymce-rte/blob/master/assets/components/tinymcerte/js/vendor/tinymce/skins/modx/skin.min.css#L312

I fixed the bugs and adjusted the styles a bit, made the theme closer to modx. And in the future it will be possible to refine the modx theme more.

![tinyrte_1](https://user-images.githubusercontent.com/12523676/92118996-da1d0600-edff-11ea-8740-8be484eb60cf.gif)

### Related issue(s)/PR(s)
N/A