### PR TITLE
Update GetTreeProcessor.php to correct reserved MySQL 8 keyword

### DIFF
--- a/core/components/tinymcerte/src/Processors/GetTreeProcessor.php
+++ b/core/components/tinymcerte/src/Processors/GetTreeProcessor.php
@@ -75,7 +75,7 @@ class GetTreeProcessor extends modProcessor
             $c->where([
                 'key:!=' => 'mgr'
             ]);
-            $c->sortby('rank');
+            $c->sortby('`rank`');
             /** @var modContext[] $contexts */
             $contexts = $this->modx->getCollection('modContext', $c);
             foreach ($contexts as $context) {

--- a/core/components/tinymcerte/src/Processors/GetTreeProcessor.php
+++ b/core/components/tinymcerte/src/Processors/GetTreeProcessor.php
@@ -75,7 +75,7 @@ class GetTreeProcessor extends modProcessor
             $c->where([
                 'key:!=' => 'mgr'
             ]);
-            $c->sortby('`rank`');
+            $c->sortby($this->xpdo->escape('rank'));
             /** @var modContext[] $contexts */
             $contexts = $this->modx->getCollection('modContext', $c);
             foreach ($contexts as $context) {


### PR DESCRIPTION
### What does it do?
Enclose the reserved MySQL keyword 'rank' in backticks.

### Why is it needed?
Without this, the SQL is invalid and returns a syntax error.

### Related issue(s)/PR(s)
#118 