### PR TITLE
Fix change tinymcerte.skin setting on update

### DIFF
--- a/_build/resolvers/resolve.update.php
+++ b/_build/resolvers/resolve.update.php
@@ -249,7 +249,7 @@ if ($object->xpdo) {
         if ($oldPackage && $oldPackage->compareVersion('3.0.3-pl', '>')) {
             removeFromSetting($modx, 'tinymcerte.plugins', 'modximage');
             addToSetting($modx, 'tinymcerte.plugins', 'quickbars');
-            changeSetting($modx, 'skin', 'modx', 'oxide');
+            changeSetting($modx, 'tinymcerte.skin', 'modx', 'oxide');
             changeSetting($modx, 'tinymcerte.toolbar1', 'link', 'modxlink');
             changeSetting($modx, 'tinymcerte.toolbar2', 'link', 'modxlink');
             changeSetting($modx, 'tinymcerte.toolbar3', 'link', 'modxlink');


### PR DESCRIPTION
### Why is it needed?
With version "3.0.3-pl", the system setting `tinymcerte.skin` still isn't changed correctly to the value `oxide` on update from an older version.

### Related issue(s)/PR(s)
#144
https://community.modx.com/t/modx-3-1-2-tinymce-rich-text-editor-3-0-not-loading/8598/9
