### PR TITLE
feat: adding additional link fields

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -3,7 +3,7 @@
   "lowCaseName": "tinymcerte",
   "description": "TinyMCE 6",
   "author": "John Peca/Thomas Jakobi",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "package": {
     "elements": {
       "plugins": [

--- a/_build/config.json
+++ b/_build/config.json
@@ -114,6 +114,12 @@
         "area": "tinymcerte.default"
       },
       {
+        "key": "enable_link_aria",
+        "value": false,
+        "type": "combo-boolean",
+        "area": "tinymcerte.default"
+      },
+      {
         "key": "links_across_contexts",
         "value": false,
         "type": "combo-boolean",

--- a/_build/resolvers/resolve.update.php
+++ b/_build/resolvers/resolve.update.php
@@ -258,6 +258,10 @@ if ($object->xpdo) {
             changeSetting($modx, 'tinymcerte.skin', 'modx', 'oxide');
         }
 
+        if ($oldPackage && $oldPackage->compareVersion('3.1.0-pl', '>')) {
+            addToSetting($modx, 'tinymcerte.plugins', 'image');
+        }
+
             break;
     }
 }

--- a/core/components/tinymcerte/docs/changelog.md
+++ b/core/components/tinymcerte/docs/changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2025-06-13
+
+### Changed
+
+- Add "rel" link field
+- Add system setting "enable_link_aria" to show "aria_label". "aria_labelledby", "aria_describedby" and "id" in link field
+
 ## [3.0.5] - 2025-06-10
 
 ### Changed

--- a/core/components/tinymcerte/lexicon/en/setting.inc.php
+++ b/core/components/tinymcerte/lexicon/en/setting.inc.php
@@ -19,6 +19,8 @@ $_lang['setting_tinymcerte.content_css'] = 'Content CSS';
 $_lang['setting_tinymcerte.content_css_desc'] = 'Load additional CSS files with TinyMCE. Use "," (comma) delimiter for multiple files. <a href="https://www.tiny.cloud/docs/configure/content-appearance/#content_css">https://www.tiny.cloud/docs/configure/content-appearance/#content_css</a>';
 $_lang['setting_tinymcerte.enable_link_list'] = 'Enable link list';
 $_lang['setting_tinymcerte.enable_link_list_desc'] = 'This option enables the nested link list in the link plugin. It can be switched off, when the link list creates a timeout on very large sites.';
+$_lang['setting_tinymcerte.enable_link_aria'] = 'Enable link Aria';
+$_lang['setting_tinymcerte.enable_link_aria_desc'] = 'This option enables the aria-label and aria-labelledby attributes for the link plugin. It can be switched off, however if aria attributes are detected on a link it will show the fields anyway.';
 $_lang['setting_tinymcerte.external_config'] = 'External config';
 $_lang['setting_tinymcerte.external_config_desc'] = 'Path to an external JSON config file. It will be merged with with the system setting defaults.';
 $_lang['setting_tinymcerte.headers_format'] = 'Headers format';

--- a/core/components/tinymcerte/src/Plugins/Events/OnRichTextEditorInit.php
+++ b/core/components/tinymcerte/src/Plugins/Events/OnRichTextEditorInit.php
@@ -135,6 +135,7 @@ class OnRichTextEditorInit extends Plugin
             'remove_script_host' => $this->tinymcerte->getOption('remove_script_host', [], true) == 1,
             'entity_encoding' => $this->tinymcerte->getOption('entity_encoding', [], 'named'),
             'enable_link_list' => $this->tinymcerte->getOption('enable_link_list', [], true) == 1,
+            'enable_link_aria' => $this->tinymcerte->getOption('enable_link_aria', [], false) == 1,
             'max_height' => (int)$this->tinymcerte->getOption('max_height', [], 500),
             'min_height' => (int)$this->tinymcerte->getOption('min_height', [], 100),
             'branding' => $this->tinymcerte->getOption('branding', [], false) == 1,

--- a/src/js/Plugins/modxlink/Data.js
+++ b/src/js/Plugins/modxlink/Data.js
@@ -19,6 +19,12 @@ export default class Data {
         this.initialData = {
             link_text: this.editor.selection.getContent(),
             link_title: '',
+            aria_label: '',
+            aria_labelledby: '',
+            aria_describedby: '',
+            aria_hidden: false,
+            id: '',
+            rel: '',
             classes: '',
             new_window: false,
             'page_page': '',
@@ -71,6 +77,12 @@ export default class Data {
 
         data.link_title = this.element.getAttribute('title') ?? '';
         data.classes = this.element.getAttribute('class') ?? '';
+        data.id = this.element.getAttribute('id') ?? '';
+        data.rel = this.element.getAttribute('rel') ?? '';
+        data.aria_label = this.element.getAttribute('aria-label') ?? '';
+        data.aria_labelledby = this.element.getAttribute('aria-labelledby') ?? '';
+        data.aria_describedby = this.element.getAttribute('aria-describedby') ?? '';
+        data.aria_hidden = this.element.getAttribute('aria-hidden') ?? false;
         data.new_window = (this.element.getAttribute('target') === '_blank');
         data.link_text = this.element.innerHTML;
 

--- a/src/js/Plugins/modxlink/Link.js
+++ b/src/js/Plugins/modxlink/Link.js
@@ -46,6 +46,30 @@ export default class Link {
         if (data.classes) {
             attributes.class = data.classes;
         }
+
+        if (data.id) {
+            attributes.id = data.id;
+        }
+
+        if (data.rel) {
+            attributes.rel = data.rel;
+        }
+
+        if (data.aria_label) {
+            attributes['aria-label'] = data.aria_label;
+        }
+
+        if (data.aria_labelledby) {
+            attributes['aria-labelledby'] = data.aria_labelledby;
+        }
+
+        if (data.aria_describedby) {
+            attributes['aria-describedby'] = data.aria_describedby;
+        }
+
+        if (data.aria_hidden) {
+            attributes['aria-hidden'] = data.aria_hidden;
+        }
         
         return attributes;
     }


### PR DESCRIPTION
### What does it do?
I've added additional fields to the links to control the "rel", "id" and "aria" attributes. To keep the link list clean, I've hidden the "id" and "aria" behind a setting that is disabled by default called "enable_link_aria" 

### Why is it needed?
This adds some missing attribute control to links for accessibility and better description of links. 

### Related issue(s)/PR(s)
#142
