### PR TITLE
Max Height + Z-Index

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -3,7 +3,7 @@
   "lowCaseName": "tinymcerte",
   "description": "TinyMCE 6",
   "author": "John Peca/Thomas Jakobi/matdave",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "package": {
     "elements": {
       "plugins": [

--- a/core/components/tinymcerte/src/Plugins/Events/OnRichTextEditorInit.php
+++ b/core/components/tinymcerte/src/Plugins/Events/OnRichTextEditorInit.php
@@ -144,7 +144,8 @@ class OnRichTextEditorInit extends Plugin
             'min_height' => (int)$this->tinymcerte->getOption('min_height', [], 100),
             'branding' => $this->tinymcerte->getOption('branding', [], false) == 1,
             'cache_suffix' => '?v=' . $this->tinymcerte->version,
-            'promotion' => false
+            'promotion' => false,
+            'content_style' => 'html {overflow-y: auto}'
         ], $this->getSettings(), $this->getProperties());
         if (!$config['width']) {
             unset($config['width']);

--- a/src/css/tinymcerte.css
+++ b/src/css/tinymcerte.css
@@ -1,5 +1,9 @@
 @import "choices.js/public/assets/styles/choices.css";
 
+.tox.tox-tinymce {
+    max-height: 90vh;
+}
+
 .tox .tox-checkbox__label {
     font-size: 14px;
 }

--- a/src/css/tinymcerte.css
+++ b/src/css/tinymcerte.css
@@ -1,6 +1,6 @@
 @import "choices.js/public/assets/styles/choices.css";
 
-.tox.tox-tinymce {
+.tox.tox-tinymce:not(.tox-fullscreen) {
     max-height: 90vh;
 }
 

--- a/src/js/modx/TinyMCE.ext.js
+++ b/src/js/modx/TinyMCE.ext.js
@@ -44,6 +44,18 @@ Ext.extend(TinyMCERTE.Tiny, Ext.Component, {
             if (that.allowDrop) {
                 that.registerDrop();
             }
+            editor.on('FullscreenStateChanged', function (e) {
+                var mc = Ext.getCmp('modx-content'),
+                    mrml = Ext.getCmp('modx-resource-main-left');
+                if (e.state) {
+                    mc.el.dom.style.zIndex = 100;
+                    mrml.el.dom.style.zIndex = 100;
+                } else {
+                    mc.el.dom.style.zIndex = null;
+                    mrml.el.dom.style.zIndex = null;
+                }
+
+            });
         };
         tinymce.init(this.cfg);
     },


### PR DESCRIPTION
### What does it do?
Sets a max height of 90vh to prevent toolbar from going off-screen on long documents, and adjusts z-index when going full screen.

### Why is it needed?
On long documents, the toolbar requires scrolling all the way up the page to get to. 
