### PR TITLE
fix: keep in git assets/components/tinymcerte/mgr/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ _packages/*
 ##################
 /src/tinymce/
 /src/*.zip
-/assets/components/tinymcerte/mgr/*
 
 # IDE files #
 #############


### PR DESCRIPTION
### What does it do?
Modified .gitignore in order to keep in git assets/components/tinymcerte/mgr/*

### Why is it needed?
When deploying from local to remote server, files are missing and tinymcerte stops working
